### PR TITLE
Fix cmake build: use target_link_libraries instead of LINK_FLAGS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,8 +34,13 @@ set_target_properties(ncvis
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES
         CXX_EXTENSIONS NO
-        LINK_FLAGS "${NCVIS_LINKER_FLAGS}"
 )
+
+# Link libraries after object files (required for GNU ld)
+target_link_options(ncvis PRIVATE -Wl,-rpath,${WXCONFIG_RPATH}/lib)
+separate_arguments(WX_LINK_LIBS UNIX_COMMAND "${WX_LINK_FLAGS}")
+separate_arguments(NC_LINK_LIBS UNIX_COMMAND "-L${NC_LIB_DIR} -lnetcdf ${NC_LINK_FLAGS}")
+target_link_libraries(ncvis PRIVATE ${WX_LINK_LIBS} ${NC_LINK_LIBS})
 
 # Install target
 INSTALL(TARGETS ncvis

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,13 +34,42 @@ set_target_properties(ncvis
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES
         CXX_EXTENSIONS NO
+        BUILD_RPATH "${WXCONFIG_RPATH}/lib"
+        INSTALL_RPATH "${WXCONFIG_RPATH}/lib"
 )
 
 # Link libraries after object files (required for GNU ld)
-target_link_options(ncvis PRIVATE -Wl,-rpath,${WXCONFIG_RPATH}/lib)
-separate_arguments(WX_LINK_LIBS UNIX_COMMAND "${WX_LINK_FLAGS}")
-separate_arguments(NC_LINK_LIBS UNIX_COMMAND "-L${NC_LIB_DIR} -lnetcdf ${NC_LINK_FLAGS}")
-target_link_libraries(ncvis PRIVATE ${WX_LINK_LIBS} ${NC_LINK_LIBS})
+separate_arguments(WX_LINK_ITEMS NATIVE_COMMAND "${WX_LINK_FLAGS}")
+separate_arguments(NC_LINK_ITEMS NATIVE_COMMAND "-lnetcdf ${NC_LINK_FLAGS}")
+target_link_directories(ncvis PRIVATE ${NC_LIB_DIR})
+
+# Split wxWidgets link items into libraries (-l...) and other linker options
+set(WX_LIBRARIES "")
+set(WX_OPTIONS "")
+foreach(item IN LISTS WX_LINK_ITEMS)
+    if(item MATCHES "^-l.+")
+        list(APPEND WX_LIBRARIES "${item}")
+    else()
+        list(APPEND WX_OPTIONS "${item}")
+    endif()
+endforeach()
+
+# Split NetCDF link items into libraries (-l...) and other linker options
+set(NC_LIBRARIES "")
+set(NC_OPTIONS "")
+foreach(item IN LISTS NC_LINK_ITEMS)
+    if(item MATCHES "^-l.+")
+        list(APPEND NC_LIBRARIES "${item}")
+    else()
+        list(APPEND NC_OPTIONS "${item}")
+    endif()
+endforeach()
+
+# Link true libraries
+target_link_libraries(ncvis PRIVATE ${WX_LIBRARIES} ${NC_LIBRARIES})
+
+# Apply non-library linker options
+target_link_options(ncvis PRIVATE ${WX_OPTIONS} ${NC_OPTIONS})
 
 # Install target
 INSTALL(TARGETS ncvis


### PR DESCRIPTION
LINK_FLAGS places library flags before object files in the linker command, causing undefined reference errors with GNU ld which requires libraries to appear after the object files that use them.

Replace LINK_FLAGS with target_link_options (for rpath) and target_link_libraries (for wxWidgets and NetCDF libraries) so that the link order is correct.