### PR TITLE
Add startup variable selection with -var option

### DIFF
--- a/src/ncvis.cpp
+++ b/src/ncvis.cpp
@@ -49,6 +49,8 @@ bool wxNcVisApp::OnInit() {
 	// Process command line arguments
 	if (argc < 2) {
 		std::cout << "Usage: " << argv[0] << " [options] <filename> [filename] ... " << std::endl;
+                std::cout << "Options:" << std::endl;
+                std::cout << "  -var <name>   Load variable on startup" << std::endl;
 		exit(-1);
 	}
 
@@ -60,7 +62,8 @@ bool wxNcVisApp::OnInit() {
 			if ((wxString("-g") == argv[iarg]) ||
 			    (wxString("-uxc") == argv[iarg]) ||
 			    (wxString("-uyc") == argv[iarg]) ||
-				(wxString("-mcr") == argv[iarg])
+		   	    (wxString("-mcr") == argv[iarg]) ||
+				(wxString("-var") == argv[iarg])
 			) {
 				if (iarg+1 == argc) {
 					std::cout << "Option " << argv[iarg] << " missing required parameter" << std::endl;
@@ -89,6 +92,8 @@ bool wxNcVisApp::OnInit() {
 	if (vecFilenames.size() == 0) {
 		std::cout << "ERROR: No filenames specified" << std::endl;
 		std::cout << "Usage: " << argv[0] << " [options] <filename> [filename] ... " << std::endl;
+                std::cout << "Options:" << std::endl;
+                std::cout << "  -var <name>   Load variable on startup" << std::endl;
 		exit(-1);
 	}
 

--- a/src/wxNcVisFrame.cpp
+++ b/src/wxNcVisFrame.cpp
@@ -133,6 +133,11 @@ wxNcVisFrame::wxNcVisFrame(
 		m_fRegional = true;
 	}
 
+        auto itVar = mapOptions.find("-var");
+        if (itVar != mapOptions.end()) {
+            m_strStartupVariable = itVar->second;
+        }
+
 	auto itMCS = mapOptions.find("-mcr");
 	if (itMCS != mapOptions.end()) {
 		m_dMaxCellRadius = stof(itMCS->second.ToStdString());
@@ -844,6 +849,37 @@ void wxNcVisFrame::InitializeWindow() {
 	//customvarsizer->Add(new wxStaticText(this, (-1), _T("Custom: "), wxDefaultPosition, wxSize(20,m_wxDataTransButton->GetSize().GetHeight()+4), wxST_ELLIPSIZE_END | wxALIGN_CENTRE_HORIZONTAL | wxALIGN_CENTER_VERTICAL), 1, wxEXPAND | wxALL, 4);
 	//customvarsizer->Add(new wxTextCtrl(this, (-1), _T(""), wxDefaultPosition, wxSize(240,m_wxDataTransButton->GetSize().GetHeight()+4), wxTE_PROCESS_ENTER), 2, wxEXPAND | wxALL, 4);
 
+
+        if (!m_strStartupVariable.IsEmpty()) {
+            bool fFound = false;
+
+            for (int vc = 0; vc < NcVarMaximumDimensions; vc++) {
+                if (m_vecwxVarSelector[vc] == NULL) {
+                    continue;
+                }
+
+                int ix = m_vecwxVarSelector[vc]->FindString(m_strStartupVariable);
+                if (ix != wxNOT_FOUND) {
+                    m_vecwxVarSelector[vc]->SetSelection(ix);
+
+                    wxCommandEvent evt(wxEVT_COMBOBOX, ID_VARSELECTOR + vc);
+                    evt.SetEventObject(m_vecwxVarSelector[vc]);
+                    evt.SetInt(ix);
+                    wxPostEvent(this, evt);
+
+                    fFound = true;
+                    break;
+                }
+            }
+
+            if (!fFound) {
+                wxMessageBox(
+                    wxString::Format("Startup variable \"%s\" not found.", m_strStartupVariable),
+                    "Variable not found",
+                    wxOK | wxICON_WARNING
+                );
+            }
+        }
 
 	// Dimensions
 	m_vardimsizer = new wxFlexGridSizer(NcVarMaximumDimensions+1, 4, 0, 0);

--- a/src/wxNcVisFrame.h
+++ b/src/wxNcVisFrame.h
@@ -676,6 +676,11 @@ private:
 	///	</summary>
 	VariableNameFileIxMap m_mapVarNames[10];
 
+        ///     <summary>
+        ///             Startup variable name.
+        ///     </summary>
+	wxString m_strStartupVariable;
+
 private:
 	///	<summary>
 	///		ColorMap index.


### PR DESCRIPTION
This PR adds a -var <variable_name> command-line option so NcVis can automatically select and load a requested variable at startup.

## What changed:

- Added parsing for -var <name> in command-line options
- Stored the requested startup variable in wxNcVisFrame
- Auto-selected the requested variable after the variable selectors are populated
- Triggered the normal variable selection flow so startup loading uses existing logic
- Updated usage text to document the new option

## Behavior:

- If the requested variable exists, it is automatically loaded on startup
- If it is not found, NcVis shows a warning and falls back to normal behavior